### PR TITLE
Bump gidgethub to 1.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiohttp==1.3.5
 async-timeout==1.2.0
 cchardet==1.1.3
 chardet==2.3.0
-gidgethub==1.1.0
+gidgethub==1.2.0
 multidict==2.1.4
 pycares==2.1.1
 unidiff==0.5.2+new.files


### PR DESCRIPTION
Has an important fix relating to webhook signature validation.